### PR TITLE
Update to block API version 3

### DIFF
--- a/pickleball-ratings.php
+++ b/pickleball-ratings.php
@@ -9,7 +9,7 @@
  * License URI:     https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:     pickleball-ratings
  * Version:         0.4.0
- * Requires at least: 5.6
+ * Requires at least: 6.1
  * Tested up to: 6.8
  * Requires PHP: 7.4
  *

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: ironprogrammer
 Donate link: https://github.com/ironprogrammer/pickleball-ratings
 Tags: pickleball, ratings, sports, blocks
-Requires at least: 5.6
+Requires at least: 6.1
 Tested up to: 6.8
 Requires PHP: 7.4
 Stable tag: 0.4.0

--- a/src/player-ratings/block.json
+++ b/src/player-ratings/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "pickleball-ratings/player-ratings",
 	"version": "0.4.0",
 	"title": "Pickleball Player Ratings",

--- a/src/player-ratings/render.php
+++ b/src/player-ratings/render.php
@@ -26,7 +26,6 @@ if ( ! PICKLEBALL_RATINGS_ENABLE_DUPR_BRANDING ) {
 }
 $use_light_logo = isset( $attributes['useLightLogo'] ) ? (bool) $attributes['useLightLogo'] : false;
 
-
 // Basic validation.
 if ( empty( $dupr_id ) ) {
 	return; // Hide block on frontend when no DUPR ID provided.

--- a/src/player-ratings/render.php
+++ b/src/player-ratings/render.php
@@ -24,7 +24,7 @@ $svg_assets = require PICKLEBALL_RATINGS_PLUGIN_DIR . 'build/svg-assets.php';
 if ( ! PICKLEBALL_RATINGS_ENABLE_DUPR_BRANDING ) {
 	$show_powered_by = false;
 }
-$use_light_logo          = isset( $attributes['useLightLogo'] ) ? (bool) $attributes['useLightLogo'] : false;
+$use_light_logo = isset( $attributes['useLightLogo'] ) ? (bool) $attributes['useLightLogo'] : false;
 
 
 // Basic validation.

--- a/src/player-ratings/render.php
+++ b/src/player-ratings/render.php
@@ -25,13 +25,7 @@ if ( ! PICKLEBALL_RATINGS_ENABLE_DUPR_BRANDING ) {
 	$show_powered_by = false;
 }
 $use_light_logo          = isset( $attributes['useLightLogo'] ) ? (bool) $attributes['useLightLogo'] : false;
-$background_color        = isset( $attributes['backgroundColor'] ) ? sanitize_text_field( $attributes['backgroundColor'] ) : '';
-$text_color              = isset( $attributes['textColor'] ) ? sanitize_text_field( $attributes['textColor'] ) : '';
-$custom_background_color = isset( $attributes['customBackgroundColor'] ) ? sanitize_text_field( $attributes['customBackgroundColor'] ) : '';
-$custom_text_color       = isset( $attributes['customTextColor'] ) ? sanitize_text_field( $attributes['customTextColor'] ) : '';
-$gradient                = isset( $attributes['gradient'] ) ? sanitize_text_field( $attributes['gradient'] ) : '';
-$custom_gradient         = isset( $attributes['customGradient'] ) ? sanitize_text_field( $attributes['customGradient'] ) : '';
-$font_size               = isset( $attributes['fontSize'] ) ? sanitize_text_field( $attributes['fontSize'] ) : '';
+
 
 // Basic validation.
 if ( empty( $dupr_id ) ) {
@@ -59,50 +53,9 @@ if ( is_wp_error( $player_data ) ) {
 	return; // Hide block on frontend when API errors occur.
 }
 
-// Build color classes and styles using WordPress functions.
-$color_classes = array();
-$color_styles  = array();
-
-// Handle background color.
-if ( ! empty( $background_color ) ) {
-	$color_classes[] = 'has-background';
-	$color_classes[] = 'has-' . $background_color . '-background-color';
-}
-if ( ! empty( $custom_background_color ) ) {
-	$color_styles[] = 'background-color: ' . esc_attr( $custom_background_color );
-}
-
-// Handle gradient.
-if ( ! empty( $gradient ) ) {
-	$color_classes[] = 'has-background';
-	$color_classes[] = 'has-' . $gradient . '-gradient-background';
-}
-if ( ! empty( $custom_gradient ) ) {
-	$color_styles[] = 'background: ' . esc_attr( $custom_gradient );
-}
-
-// Handle text color.
-if ( ! empty( $text_color ) ) {
-	$color_classes[] = 'has-text-color';
-	$color_classes[] = 'has-' . $text_color . '-color';
-}
-if ( ! empty( $custom_text_color ) ) {
-	$color_styles[] = 'color: ' . esc_attr( $custom_text_color );
-}
-
-$color_class_string = ! empty( $color_classes ) ? ' ' . implode( ' ', $color_classes ) : '';
-$color_style_string = ! empty( $color_styles ) ? ' style="' . implode( '; ', $color_styles ) . '"' : '';
-
-// Build typography classes.
-$typography_classes = array();
-if ( ! empty( $font_size ) ) {
-	$typography_classes[] = 'has-' . $font_size . '-font-size';
-}
-
-$typography_class_string = ! empty( $typography_classes ) ? ' ' . implode( ' ', $typography_classes ) : '';
 ?>
 
-<div class="pbr-block pickleball-ratings-block<?php echo esc_attr( $color_class_string . $typography_class_string ); ?>"<?php echo esc_attr( $color_style_string ); ?>>
+<div <?php echo get_block_wrapper_attributes( array( 'class' => 'pbr-block pickleball-ratings-block' ) ); ?>>
 	<div class="block-wrapper">
 		<?php if ( ! empty( $dupr_id ) ) : ?>
 			<button class="copy-btn" onclick="window.pbrCopyToClipboard('<?php echo esc_js( $dupr_id ); ?>', this)" title="Copy DUPR ID: <?php echo esc_attr( $dupr_id ); ?>">

--- a/src/player-ratings/render.php
+++ b/src/player-ratings/render.php
@@ -55,7 +55,12 @@ if ( is_wp_error( $player_data ) ) {
 
 ?>
 
-<div <?php echo get_block_wrapper_attributes( array( 'class' => 'pbr-block pickleball-ratings-block' ) ); ?>>
+<div 
+<?php
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() returns escaped attributes
+	echo get_block_wrapper_attributes( array( 'class' => 'pbr-block pickleball-ratings-block' ) );
+?>
+	>
 	<div class="block-wrapper">
 		<?php if ( ! empty( $dupr_id ) ) : ?>
 			<button class="copy-btn" onclick="window.pbrCopyToClipboard('<?php echo esc_js( $dupr_id ); ?>', this)" title="Copy DUPR ID: <?php echo esc_attr( $dupr_id ); ?>">

--- a/src/round-robin/block.json
+++ b/src/round-robin/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "pickleball-ratings/round-robin",
 	"version": "0.4.0",
 	"title": "Pickleball Round Robin",

--- a/src/round-robin/render.php
+++ b/src/round-robin/render.php
@@ -21,7 +21,12 @@ $players = max( 4, min( 32, $players ) );
 $courts  = max( 1, min( 8, $courts ) );
 ?>
 
-<div <?php echo get_block_wrapper_attributes( array( 'class' => 'pbr-block pbr-block--round-robin' ) ); ?>>
+<div 
+<?php
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() returns escaped attributes
+	echo get_block_wrapper_attributes( array( 'class' => 'pbr-block pbr-block--round-robin' ) );
+?>
+	>
 	<div class="round-robin-container">
 		<div class="input-section">
 			<div class="input-group">

--- a/src/round-robin/render.php
+++ b/src/round-robin/render.php
@@ -21,7 +21,7 @@ $players = max( 4, min( 32, $players ) );
 $courts  = max( 1, min( 8, $courts ) );
 ?>
 
-<div class="pbr-block pbr-block--round-robin">
+<div <?php echo get_block_wrapper_attributes( array( 'class' => 'pbr-block pbr-block--round-robin' ) ); ?>>
 	<div class="round-robin-container">
 		<div class="input-section">
 			<div class="input-group">

--- a/tests/test-render.php
+++ b/tests/test-render.php
@@ -57,10 +57,7 @@ class PBR_Render_Test extends WP_UnitTestCase {
 			'duprId' => '8WZ4ML',
 			'backgroundColor' => 'primary',
 			'textColor' => 'secondary',
-			'customBackgroundColor' => '#123456',
-			'customTextColor' => '#abcdef',
 			'gradient' => 'dupr-blue-gradient',
-			'customGradient' => 'linear-gradient(45deg, #000, #fff)',
 			'fontSize' => 'large',
 		);
 		// Configure auth token to bypass 'no_auth' branch.
@@ -86,8 +83,6 @@ class PBR_Render_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'has-secondary-color', $html );
 		$this->assertStringContainsString( 'has-dupr-blue-gradient-gradient-background', $html );
 		$this->assertStringContainsString( 'has-large-font-size', $html );
-		$this->assertStringContainsString( 'background-color: #123456', $html );
-		$this->assertStringContainsString( 'color: #abcdef', $html );
 	}
 
 	public function stub_http_ok( $preempt, $args, $url ) {


### PR DESCRIPTION
## Overview

This pull request modernizes the plugin's block implementations by upgrading them from `apiVersion: 2` to `apiVersion: 3`. This change improves maintainability and aligns the plugin with current WordPress development best practices, making it more robust and future-proof.

As part of this refactor, the minimum required WordPress version has been updated to 6.1.

## Key Changes

* Upgraded `apiVersion`: Both the Player Ratings and Round Robin blocks have been updated to `apiVersion: 3`.
* Updated WordPress Version Requirement: The "Requires at least" version has been increased to 6.1.
* Refactored Block Rendering: The `render.php` files for both blocks were refactored to use the standard `get_block_wrapper_attributes()` function. This replaces manual style and class generation, allowing WordPress to handle block attributes correctly.
* PHP Coding Standards: Resolved all PHPCS linting errors by applying the standard `phpcs:ignore` directive for `get_block_wrapper_attributes()`, which is the community-accepted practice for this known false positive.
