### PR TITLE
Migrate block data fetching to REST API

### DIFF
--- a/includes/class-pbr-ajax-handler.php
+++ b/includes/class-pbr-ajax-handler.php
@@ -36,7 +36,6 @@ class PBR_Ajax_Handler {
 
 		$this->api = new PBR_DUPR_API();
 		add_action( 'wp_ajax_pickleball_ratings_test_dupr_connection', array( $this, 'test_connection' ) );
-		add_action( 'wp_ajax_pickleball_ratings_get_player_data', array( $this, 'get_player_data' ) );
 	}
 
 	/**
@@ -69,35 +68,6 @@ class PBR_Ajax_Handler {
 			if ( function_exists( 'pbr_log' ) ) {
 				pbr_log( 'AJAX: test_connection successful' );
 			}
-			wp_send_json_success( $result );
-		}
-	}
-
-	/**
-	 * Get player data via AJAX.
-	 */
-	public function get_player_data() {
-		// Check nonce.
-		if ( ! check_ajax_referer( 'pickleball_ratings_get_player_data', 'nonce', false ) ) {
-			wp_send_json_error( 'Security check failed' );
-		}
-
-		// Check permissions (allow for logged-in users).
-		if ( ! is_user_logged_in() ) {
-			wp_send_json_error( 'Authentication required' );
-		}
-
-		$dupr_id = isset( $_POST['dupr_id'] ) ? sanitize_text_field( wp_unslash( $_POST['dupr_id'] ) ) : '';
-
-		if ( empty( $dupr_id ) ) {
-			wp_send_json_error( 'DUPR ID is required' );
-		}
-
-		$result = $this->api->get_player_data( $dupr_id );
-
-		if ( is_wp_error( $result ) ) {
-			wp_send_json_error( $result->get_error_message() );
-		} else {
 			wp_send_json_success( $result );
 		}
 	}

--- a/includes/class-pbr-rest-controller.php
+++ b/includes/class-pbr-rest-controller.php
@@ -71,7 +71,7 @@ class PBR_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function get_player_permissions_check( $request ) {
+	public function get_player_permissions_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		if ( ! current_user_can( 'edit_posts' ) ) {
 			return new WP_Error( 'rest_forbidden', esc_html__( 'You do not have permissions to view player data.', 'pickleball-ratings' ), array( 'status' => 401 ) );
 		}

--- a/includes/class-pbr-rest-controller.php
+++ b/includes/class-pbr-rest-controller.php
@@ -35,10 +35,10 @@ class PBR_REST_Controller {
 				'permission_callback' => array( $this, 'get_player_permissions_check' ),
 				'args'                => array(
 					'dupr_id' => array(
-						'description' => __( 'The DUPR ID of the player.', 'pickleball-ratings' ),
-						'type'        => 'string',
-						'required'    => true,
-						'validate_callback' => function( $param ) {
+						'description'       => __( 'The DUPR ID of the player.', 'pickleball-ratings' ),
+						'type'              => 'string',
+						'required'          => true,
+						'validate_callback' => function ( $param ) {
 							return preg_match( '/^[A-Z0-9]{6}$/', $param );
 						},
 					),

--- a/includes/class-pbr-rest-controller.php
+++ b/includes/class-pbr-rest-controller.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * REST API Controller for the Pickleball Ratings plugin.
+ *
+ * @package Pickleball_Ratings
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class PBR_REST_Controller.
+ */
+class PBR_REST_Controller {
+
+	/**
+	 * The namespace for the REST API.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'pickleball-ratings/v1';
+
+	/**
+	 * Register the routes for the objects of the controller.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/player/(?P<dupr_id>[\w-]+)',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_player' ),
+				'permission_callback' => array( $this, 'get_player_permissions_check' ),
+				'args'                => array(
+					'dupr_id' => array(
+						'description' => __( 'The DUPR ID of the player.', 'pickleball-ratings' ),
+						'type'        => 'string',
+						'required'    => true,
+						'validate_callback' => function( $param ) {
+							return preg_match( '/^[A-Z0-9]{6}$/', $param );
+						},
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get player data.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_player( $request ) {
+		$dupr_id = $request->get_param( 'dupr_id' );
+		$api     = new PBR_DUPR_API();
+		$data    = $api->get_player_data( $dupr_id );
+
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Check if a given request has access to get player data.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_player_permissions_check( $request ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new WP_Error( 'rest_forbidden', esc_html__( 'You do not have permissions to view player data.', 'pickleball-ratings' ), array( 'status' => 401 ) );
+		}
+		return true;
+	}
+}

--- a/pickleball-ratings.php
+++ b/pickleball-ratings.php
@@ -117,6 +117,7 @@ function pbr_log( $message, $context = array() ) {
 // Include required files.
 require_once PICKLEBALL_RATINGS_PLUGIN_DIR . 'includes/class-pbr-dupr-api.php';
 require_once PICKLEBALL_RATINGS_PLUGIN_DIR . 'includes/class-pbr-ajax-handler.php';
+require_once PICKLEBALL_RATINGS_PLUGIN_DIR . 'includes/class-pbr-rest-controller.php';
 require_once PICKLEBALL_RATINGS_PLUGIN_DIR . 'admin/class-pbr-admin-settings.php';
 
 /**
@@ -161,6 +162,15 @@ function pickleball_ratings_ajax_init() {
 	}
 }
 add_action( 'wp_loaded', 'pickleball_ratings_ajax_init' );
+
+/**
+ * Initialize the REST API.
+ */
+function pickleball_ratings_rest_api_init() {
+	$controller = new PBR_REST_Controller();
+	$controller->register_routes();
+}
+add_action( 'rest_api_init', 'pickleball_ratings_rest_api_init' );
 
 /**
  * Add settings link to plugin list.

--- a/pickleball-ratings.php
+++ b/pickleball-ratings.php
@@ -202,9 +202,10 @@ function pickleball_ratings_register_block() {
 	// Localize script for AJAX.
 	wp_localize_script(
 		'pickleball-ratings-player-ratings-editor-script',
-		'duprRatingAjax',
+		'pbrBlockEditor',
 		array(
-			'nonce'              => wp_create_nonce( 'pickleball_ratings_get_player_data' ),
+			'rest_url'           => esc_url_raw( rest_url( 'pickleball-ratings/v1' ) ),
+			'nonce'              => wp_create_nonce( 'wp_rest' ),
 			'pluginUrl'          => PICKLEBALL_RATINGS_PLUGIN_URL,
 			'enableDuprBranding' => PICKLEBALL_RATINGS_ENABLE_DUPR_BRANDING,
 		)

--- a/src/player-ratings/edit.js
+++ b/src/player-ratings/edit.js
@@ -1,4 +1,4 @@
-/* global duprRatingAjax */
+/* global pbrBlockEditor */
 import { __ } from '@wordpress/i18n';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
@@ -70,28 +70,28 @@ export default function Edit( { attributes, setAttributes } ) {
 			setApiError( '' );
 
 			try {
-				const response = await fetch( '/wp-admin/admin-ajax.php', {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/x-www-form-urlencoded',
-					},
-					body: new URLSearchParams( {
-						action: 'pickleball_ratings_get_player_data',
-						dupr_id: id,
-						nonce: duprRatingAjax.nonce,
-					} ),
-				} );
+				const response = await fetch(
+					`${ pbrBlockEditor.rest_url }/player/${ id }`,
+					{
+						method: 'GET',
+						headers: {
+							'X-WP-Nonce': pbrBlockEditor.nonce,
+						},
+					}
+				);
 
 				const result = await response.json();
 
-				if ( result.success ) {
-					setPlayerData( result.data );
+				if ( response.ok ) {
+					setPlayerData( result );
 				} else {
-					setApiError( result.data );
+					setApiError(
+						result.message || 'An unknown error occurred.'
+					);
 					setPlayerData( null );
 				}
 			} catch ( error ) {
-				setApiError( 'Failed to fetch player data' );
+				setApiError( 'Failed to fetch player data.' );
 				setPlayerData( null );
 			} finally {
 				setIsLoading( false );
@@ -173,7 +173,7 @@ export default function Edit( { attributes, setAttributes } ) {
 						__nextHasNoMarginBottom={ true }
 					/>
 
-					{ duprRatingAjax?.enableDuprBranding && (
+					{ pbrBlockEditor?.enableDuprBranding && (
 						<ToggleControl
 							label={ __(
 								'Show Powered by DUPR',
@@ -190,7 +190,7 @@ export default function Edit( { attributes, setAttributes } ) {
 							__nextHasNoMarginBottom={ true }
 						/>
 					) }
-					{ duprRatingAjax?.enableDuprBranding && showPoweredBy && (
+					{ pbrBlockEditor?.enableDuprBranding && showPoweredBy && (
 						<ToggleControl
 							label={ __(
 								'Use Light Logo',
@@ -396,14 +396,14 @@ export default function Edit( { attributes, setAttributes } ) {
 									</span>
 								</div>
 							</div>
-							{ duprRatingAjax?.enableDuprBranding &&
+							{ pbrBlockEditor?.enableDuprBranding &&
 								showPoweredBy && (
 									<div className="footer">
 										<span className="powered-by">
 											Powered by{ ' ' }
 											<img
 												src={
-													duprRatingAjax.pluginUrl +
+													pbrBlockEditor.pluginUrl +
 													( useLightLogo
 														? 'images/dupr-logo-white.png'
 														: 'images/dupr-logo-blue.png' )


### PR DESCRIPTION
## Overview

This refactor modernizes the plugin by migrating the Player Ratings block's data fetching from the legacy 
`admin-ajax.php` handler to the WordPress REST API. This improves performance, scalability, and aligns the 
plugin with current best practices.

The existing AJAX functionality for the admin settings page ("Test Connection") has been preserved for now.

## Key Changes:

* New REST API Endpoint: A new `GET /wp-json/pickleball-ratings/v1/player/<dupr_id>` endpoint was created to 
   handle fetching player data for the block editor. This is managed by a new `PBR_REST_Controller` class.
* Updated Block Editor: The block's JavaScript was updated to call the new REST API endpoint, and the 
   localized script data was updated accordingly.
* AJAX Handler Cleanup: The `PBR_Ajax_Handler` class was refactored to remove the now-obsolete `get_player_data`
   action, leaving only the code required by the admin settings page.
