### PR TITLE
Extend WP_REST_Controller

### DIFF
--- a/includes/class-pbr-player-rest-controller.php
+++ b/includes/class-pbr-player-rest-controller.php
@@ -136,28 +136,28 @@ class PBR_Player_REST_Controller extends WP_REST_Controller {
 			'title'      => 'player',
 			'type'       => 'object',
 			'properties' => array(
-				'dupr_id' => array(
+				'dupr_id'             => array(
 					'description' => __( 'The DUPR ID of the player.', 'pickleball-ratings' ),
 					'type'        => 'string',
 					'readonly'    => true,
 				),
-				'name' => array(
+				'name'                => array(
 					'description' => __( 'The name of the player.', 'pickleball-ratings' ),
 					'type'        => 'string',
 					'readonly'    => true,
 				),
-				'profile_image' => array(
+				'profile_image'       => array(
 					'description' => __( 'The URL of the player\'s profile image.', 'pickleball-ratings' ),
 					'type'        => 'string',
 					'format'      => 'uri',
 					'readonly'    => true,
 				),
-				'doubles_rating' => array(
+				'doubles_rating'      => array(
 					'description' => __( 'The player\'s doubles rating.', 'pickleball-ratings' ),
 					'type'        => 'string',
 					'readonly'    => true,
 				),
-				'singles_rating' => array(
+				'singles_rating'      => array(
 					'description' => __( 'The player\'s singles rating.', 'pickleball-ratings' ),
 					'type'        => 'string',
 					'readonly'    => true,
@@ -172,7 +172,7 @@ class PBR_Player_REST_Controller extends WP_REST_Controller {
 					'type'        => array( 'integer', 'null' ),
 					'readonly'    => true,
 				),
-				'last_updated' => array(
+				'last_updated'        => array(
 					'description' => __( 'The date and time the player data was last updated.', 'pickleball-ratings' ),
 					'type'        => 'string',
 					'format'      => 'date-time',

--- a/includes/class-pbr-rest-controller.php
+++ b/includes/class-pbr-rest-controller.php
@@ -31,8 +31,8 @@ class PBR_REST_Controller {
 			'/player/(?P<dupr_id>[\w-]+)',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_player' ),
-				'permission_callback' => array( $this, 'get_player_permissions_check' ),
+				'callback'            => array( $this, 'get_item' ),
+				'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				'args'                => array(
 					'dupr_id' => array(
 						'description'       => __( 'The DUPR ID of the player.', 'pickleball-ratings' ),
@@ -93,8 +93,8 @@ class PBR_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
-	public function get_player( $request ) {
 		$dupr_id = $request->get_param( 'dupr_id' );
+	public function get_item( $request ) {
 		$api     = new PBR_DUPR_API();
 		$data    = $api->get_player_data( $dupr_id );
 
@@ -111,7 +111,7 @@ class PBR_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function get_player_permissions_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+	public function get_item_permissions_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		if ( ! current_user_can( 'edit_posts' ) ) {
 			return new WP_Error( 'rest_forbidden', esc_html__( 'You do not have permissions to view player data.', 'pickleball-ratings' ), array( 'status' => 401 ) );
 		}

--- a/includes/class-pbr-rest-controller.php
+++ b/includes/class-pbr-rest-controller.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class PBR_REST_Controller.
  */
-class PBR_REST_Controller {
+class PBR_REST_Controller extends WP_REST_Controller {
 
 	/**
 	 * The namespace for the REST API.

--- a/includes/class-pbr-rest-controller.php
+++ b/includes/class-pbr-rest-controller.php
@@ -124,4 +124,61 @@ class PBR_REST_Controller {
 		}
 		return true;
 	}
+
+	/**
+	 * Get the schema for a single player, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'player',
+			'type'       => 'object',
+			'properties' => array(
+				'dupr_id' => array(
+					'description' => __( 'The DUPR ID of the player.', 'pickleball-ratings' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
+				'name' => array(
+					'description' => __( 'The name of the player.', 'pickleball-ratings' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
+				'profile_image' => array(
+					'description' => __( 'The URL of the player\'s profile image.', 'pickleball-ratings' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'readonly'    => true,
+				),
+				'doubles_rating' => array(
+					'description' => __( 'The player\'s doubles rating.', 'pickleball-ratings' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
+				'singles_rating' => array(
+					'description' => __( 'The player\'s singles rating.', 'pickleball-ratings' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
+				'doubles_reliability' => array(
+					'description' => __( 'The reliability of the player\'s doubles rating.', 'pickleball-ratings' ),
+					'type'        => array( 'integer', 'null' ),
+					'readonly'    => true,
+				),
+				'singles_reliability' => array(
+					'description' => __( 'The reliability of the player\'s singles rating.', 'pickleball-ratings' ),
+					'type'        => array( 'integer', 'null' ),
+					'readonly'    => true,
+				),
+				'last_updated' => array(
+					'description' => __( 'The date and time the player data was last updated.', 'pickleball-ratings' ),
+					'type'        => 'string',
+					'format'      => 'date-time',
+					'readonly'    => true,
+				),
+			),
+		);
+	}
 }

--- a/includes/class-pbr-rest-controller.php
+++ b/includes/class-pbr-rest-controller.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class PBR_REST_Controller.
  */
-class PBR_REST_Controller extends WP_REST_Controller {
+class PBR_Player_REST_Controller extends WP_REST_Controller {
 
 	/**
 	 * The namespace for the REST API.

--- a/includes/class-pbr-rest-controller.php
+++ b/includes/class-pbr-rest-controller.php
@@ -23,18 +23,25 @@ class PBR_REST_Controller {
 	protected $namespace = 'pickleball-ratings/v1';
 
 	/**
+	 * The base of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'player';
+
+	/**
 	 * Register the routes for the objects of the controller.
 	 */
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			'/player/(?P<dupr_id>[\w-]+)',
+			'/' . $this->rest_base . '/(?P<id>[\w-]+)',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				'args'                => array(
-					'dupr_id' => array(
+					'id' => array(
 						'description'       => __( 'The DUPR ID of the player.', 'pickleball-ratings' ),
 						'type'              => 'string',
 						'required'          => true,
@@ -93,8 +100,8 @@ class PBR_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
-		$dupr_id = $request->get_param( 'dupr_id' );
 	public function get_item( $request ) {
+		$dupr_id = $request->get_param( 'id' );
 		$api     = new PBR_DUPR_API();
 		$data    = $api->get_player_data( $dupr_id );
 

--- a/pickleball-ratings.php
+++ b/pickleball-ratings.php
@@ -116,7 +116,7 @@ function pbr_log( $message, $context = array() ) {
 
 // Include required files.
 require_once PICKLEBALL_RATINGS_PLUGIN_DIR . 'includes/class-pbr-dupr-api.php';
-require_once PICKLEBALL_RATINGS_PLUGIN_DIR . 'includes/class-pbr-rest-controller.php';
+require_once PICKLEBALL_RATINGS_PLUGIN_DIR . 'includes/class-pbr-player-rest-controller.php';
 require_once PICKLEBALL_RATINGS_PLUGIN_DIR . 'admin/class-pbr-admin-settings.php';
 
 /**

--- a/pickleball-ratings.php
+++ b/pickleball-ratings.php
@@ -154,7 +154,7 @@ add_action( 'init', 'pickleball_ratings_admin_init' );
  * Initialize the REST API.
  */
 function pickleball_ratings_rest_api_init() {
-	$controller = new PBR_REST_Controller();
+	$controller = new PBR_Player_REST_Controller();
 	$controller->register_routes();
 }
 add_action( 'rest_api_init', 'pickleball_ratings_rest_api_init' );


### PR DESCRIPTION
## Overview

This pull request refactors the plugin's REST API to align with WordPress best practices by extending the 
`WP_REST_Controller` class. This modernization improves the structure, maintainability, and future 
extensibility of the API (e.g. for bulk player data retrieval). The controller has also been renamed to be more specific to the resource it manages.

## Key Changes

 * Extend `WP_REST_Controller`: The `PBR_Player_REST_Controller` now extends the core `WP_REST_Controller` class, 
   providing a more robust and standardized foundation for the REST API.
 * Schema Definition: A schema for the player resource has been added via the `get_item_schema()` method. This 
   schema accurately reflects the data structure returned by the DUPR API, improving the self-documenting 
   nature of the API.
 * Convention-based Naming: Methods for retrieving a single player and checking permissions have been renamed to align with `WP_REST_Controller` conventions.
 * Controller Renaming: For clarity and future expansion, the controller has been renamed:
     * `includes/class-pbr-rest-controller.php` ==> `includes/class-pbr-player-rest-controller.php`
     * `PBR_REST_Controller` ==> `PBR_Player_REST_Controller`
 * Route Updates: The route for retrieving a single player is now `/player/(?P<id>[\w-]+)`, using `id` as the 
   identifier to follow common REST API conventions.
