### PR TITLE
Bump version to v0.5.0 for development

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,14 +7,14 @@ This workflow outlines the standard process for cutting a new stable release for
 This commit is the final state of the release. All changes and version numbers must be accurate at this stage. Tagging here ensures it's pushed along with the correct commit. Use an **annotated tag** (`-a`) for all official releases.
 
 1. **Release PR:** Create a PR for the release branch.
-2. **Version Check:** Verify that the `Version:` header in `pickleball-ratings.php` and the `Stable tag:` in `readme.txt` match the **new release version** (e.g., `1.2.2`).
+2. **Version Check:** Verify that the `Version:` header in `pickleball-ratings.php`, the `version` in `package.json`, and the `Stable tag:` in `readme.txt` match the **new release version** (e.g., `1.2.2`).
 3. **Metadata Check:** Verify that `Requires at least:`, `Requires PHP:`, and other metadata in `pickleball-ratings.php` are current.
 4. **Update Changelog:** Add the new version and its changes to the `== Changelog ==` section in `readme.txt`, including an `== Upgrade Notice ==` if applicable. (Refer to past [releases](https://github.com/ironprogrammer/pickleball-ratings/releases) for examples.)
 
 | Action | Git Command Example |
 | :--- | :--- |
 | **Release PR** | `git checkout -b release/v1.2.2` |
-| **Stage Files** | `git add pickleball-ratings.php readme.txt` |
+| **Stage Files** | `git add pickleball-ratings.php package.json readme.txt` |
 | **Create Annotated Tag** | `git tag -a v1.2.2 -m "Release 1.2.2"` |
 
 ## 2. Commit and Push (Local & Remote)
@@ -44,12 +44,12 @@ Create a GitHub Release to provides formal documentation and asset management.
 
 Immediately after the release is live, bump the version number on the `trunk` branch. This ensures that any subsequent work reflects the version of the *next* expected release, preventing accidental use of the just-released version number for new development.
 
-* **Bump Version:** Update the `Version:` header in `pickleball-ratings.php` nad `Stable tag:` in `readme.txt` to the **next development version** (e.g., `1.2.3`).
+* **Bump Version:** Update the `Version:` header in `pickleball-ratings.php`, the `version` in `package.json`, and the `Stable tag:` in `readme.txt` to the **next development version** (e.g., `1.2.3`).
 
 | Action | Git Command Example |
 | :--- | :--- |
 | **Update Files** | *Manually update version to next major/minor/patch.* |
-| **Stage Files** | `git add pickleball-ratings.php readme.txt` |
+| **Stage Files** | `git add pickleball-ratings.php package.json readme.txt` |
 | **Commit Changes** | `git commit -m "Bump version to v1.2.3 for development"` |
 | **Push Branch** | `git push origin trunk` |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pickleball-ratings",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"description": "Display pickleball player ratings using a customizable block.",
 	"main": "build/index.js",
 	"scripts": {

--- a/pickleball-ratings.php
+++ b/pickleball-ratings.php
@@ -8,7 +8,7 @@
  * License:         GPLv2 or later
  * License URI:     https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:     pickleball-ratings
- * Version:         0.4.0
+ * Version:         0.5.0
  * Requires at least: 6.1
  * Tested up to: 6.8
  * Requires PHP: 7.4
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'PICKLEBALL_RATINGS_VERSION', '0.4.0' );
+define( 'PICKLEBALL_RATINGS_VERSION', '0.5.0' );
 define( 'PICKLEBALL_RATINGS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PICKLEBALL_RATINGS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: pickleball, ratings, sports, blocks
 Requires at least: 6.1
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 0.4.0
+Stable tag: 0.5.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Post-release version bump following the v0.4.0 release.

Updates version numbers in `pickleball-ratings.php` and `readme.txt` to 0.5.0 for ongoing development work.

Follows the process outlined in RELEASE.md (step 4).